### PR TITLE
Add stat per min columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # player-scraper
+
 A utility for generating a CSV export of all players for a particular ESMS game.
 
 ### Supported games
@@ -12,31 +13,30 @@ A utility for generating a CSV export of all players for a particular ESMS game.
 
 1. Download the [latest version](https://github.com/esmshub/player-scraper/releases/latest) of the scraper for your OS. If you are unsure about which version you need, [see this guide](#versions)
 
-    <img src=".github/img/empty_folder.png" width="350px">
-
+<img src=".github/img/empty_folder.png" width="350px">
 
 2. Double click the exe to run with the [default settings](#Configuration) (UI mode is enabled by default)
 
-    <img src=".github/img/scraper_ui.png" width="350px">
+   <img src=".github/img/scraper_ui.png" width="350px">
 
-    Choose your scrape mode and fill out the required fields (or accept the default values).
+   Choose your scrape mode and fill out the required fields (or accept the default values).
 
 3. Once finished, you should see something like this:
 
-    <img src=".github/img/scraper_done.png" width="350px">
+   <img src=".github/img/scraper_done.png" width="350px">
 
-     *_If there are any errors during the scrape those will be listed at the bottom, the scraper will still generate a final report with the information it was able to scrape._
-     
-     At this point the scraper is done so you can go ahead and press the Enter/Return key to close the window. A CSV formatted report containing all player information should now be available in the output directory you specified (or the default location) e.g.
+   \*_If there are any errors during the scrape those will be listed at the bottom, the scraper will still generate a final report with the information it was able to scrape._
 
-    <img src=".github/img/after_scrape.png" width="350px">
+   At this point the scraper is done so you can go ahead and press the Enter/Return key to close the window. A CSV formatted report containing all player information should now be available in the output directory you specified (or the default location) e.g.
+
+   <img src=".github/img/after_scrape.png" width="350px">
 
 4. Open the generated CSV file (i.e. `<game>_players_<timestamp>.csv`) in Excel (or equivalent) for advanced search & filtering
 
-    <img src=".github/img/excel_example.png" width="350px">
-
+<img src=".github/img/excel_example.png" width="350px">
 
 ### Mac / Linux
+
 ```
 # SSL
 ./ssl_scraper
@@ -47,7 +47,7 @@ A utility for generating a CSV export of all players for a particular ESMS game.
 
 ### Configuration
 
-The configuration options are mostly the same across all games, if you want to see what options are available run the executable from the command line with the `-h` flag 
+The configuration options are mostly the same across all games, if you want to see what options are available run the executable from the command line with the `-h` flag
 
 ```
 <Game> Player Scraper
@@ -57,6 +57,8 @@ Usage of <game>_scraper:
         Run in CI mode and disable prompts (default false)
   -download-files
         Download the latest rosters from the <Game> website (default false)
+  -excel-export
+        Use Excel-compatible formulas instead of raw values (default true)
   -max-concurrent int
         Number of concurrent requests when loading rosters (default 5)
   -output-dir string
@@ -76,6 +78,7 @@ If looking to run the scraper in a CI environment or from a script, pass the `-c
 1. Open Command Prompt / Terminal
 2. Switch to directory executable is in e.g. `cd C:\path\to\rosters`
 3. Call the executable with the `-ci` flag and [configure](#configuration) with the appropriate flags e.g.
+
 ```
 # an example of a scrape + download
 C:\path\to\rosters> ssl_scraper -ci -download-files
@@ -84,15 +87,17 @@ C:\path\to\rosters> ssl_scraper -ci -download-files
 **Scenario 1 - Increase the scrape speed**
 
 The throughput of the scraper can be adjusted via the `-max-concurrent` flag. The default is `5`, if you increased this to say `10` then the scrape should run in half the time (and vice versa) i.e.
+
 ```
 <game>_scraper -max-concurrent=10
 ```
 
-*Note - be mindful that increasing the concurrency will put additional load onto the relevant game website (and your local machine) so use sensibly*
+_Note - be mindful that increasing the concurrency will put additional load onto the relevant game website (and your local machine) so use sensibly_
 
 **Scenario 2 - Stop the scrape if an error occurs at any point**
 
 By default, the scraper will ignore errors and keep going. If you want to stop the scraper as soon as possible then use the `-stop-on-error` flag:
+
 ```
 <game>_scraper -stop-on-error
 ```
@@ -100,17 +105,18 @@ By default, the scraper will ignore errors and keep going. If you want to stop t
 ## Troubleshooting
 
 ### My virus-scanning software thinks the application is infected
+
 Your virus-scanning software may flag this application, but there’s no cause for concern. This is a well-known issue with applications built using the Go programming language. You can find more details here: [Go FAQ](https://go.dev/doc/faq#virus).
 
 Our application is completely open-source, meaning anyone can inspect the code to verify its safety. If you have any concerns, you’re welcome to review the source code yourself or run additional independent checks.
 
 ## Versions
 
-OS | Arch | File
---- | --- | ---
-Windows 10 or later | 64-bit | `*.windows_amd64.zip`
-Windows 10 or later | 32-bit | `*.windows_386.zip`
-Windows 7 or later | 64-bit | `*.win7_amd64.zip`
-Windows 7 or later | 32-bit | `*.win7_386.zip`
-macOS 10.15 Catalina or later | Universal | `*.darwin.zip`
-Linux (most distributions) | 64-bit | `*.linux_amd64.tar.gz`
+| OS                            | Arch      | File                   |
+| ----------------------------- | --------- | ---------------------- |
+| Windows 10 or later           | 64-bit    | `*.windows_amd64.zip`  |
+| Windows 10 or later           | 32-bit    | `*.windows_386.zip`    |
+| Windows 7 or later            | 64-bit    | `*.win7_amd64.zip`     |
+| Windows 7 or later            | 32-bit    | `*.win7_386.zip`       |
+| macOS 10.15 Catalina or later | Universal | `*.darwin.zip`         |
+| Linux (most distributions)    | 64-bit    | `*.linux_amd64.tar.gz` |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Usage of <game>_scraper:
   -download-files
         Download the latest rosters from the <Game> website (default false)
   -excel-export
-        Use Excel-compatible formulas instead of raw values (default true)
+        Use Excel-compatible formulas instead of raw values for calculated fields (default true)
   -max-concurrent int
         Number of concurrent requests when loading rosters (default 5)
   -output-dir string

--- a/cmd/ffo/main.go
+++ b/cmd/ffo/main.go
@@ -21,11 +21,12 @@ import (
 
 var (
 	flagTeamsUrl      = flag.String("teams-url", "https://www.ffomanager.com/clubs.html", "URL to scrape for team information on FFO website")
-	flagDownloadFiles = flag.Bool("download-files", true, "Download the latest rosters from the FFO website")
+	flagDownloadFiles = flag.Bool("download-files", false, "Download the latest rosters from the FFO website")
 	flagRostersDir    = flag.String("rosters-dir", ".", "Target directory for downloading or sourcing local rosters")
 	flagOutputDir     = flag.String("output-dir", ".", "Output directory for CSV files")
 	flagMaxParallel   = flag.Int("max-concurrent", 5, "Number of concurrent requests when loading roster files")
 	flagStopOnError   = flag.Bool("stop-on-error", false, "Stop all requests on first error")
+	flagExcelExport   = flag.Bool("excel-export", true, "Use Excel-compatible formulas instead of raw values")
 	flagCiMode        = flag.Bool("ci", false, "Run in CI mode and disable prompts")
 )
 
@@ -44,6 +45,7 @@ func main() {
 		DownloadFiles: *flagDownloadFiles,
 		RosterDir:     *flagRostersDir,
 		OutputDir:     *flagOutputDir,
+		ExcelExport:   *flagExcelExport,
 	}
 
 	ciMode := true
@@ -134,7 +136,7 @@ func main() {
 
 	pw.Stop()
 
-	_, err = core.ExportToCsv(rosters, opts.OutputDir, "ffo_players_", "FFO Player List")
+	_, err = core.ExportToCsv(rosters, opts.OutputDir, opts.ExcelExport, "ffo_players_", "FFO Player List")
 	if err != nil {
 		log.Fatalf("Failed to create output CSV file: %v", err)
 	}

--- a/cmd/ffo/main.go
+++ b/cmd/ffo/main.go
@@ -26,7 +26,7 @@ var (
 	flagOutputDir     = flag.String("output-dir", ".", "Output directory for CSV files")
 	flagMaxParallel   = flag.Int("max-concurrent", 5, "Number of concurrent requests when loading roster files")
 	flagStopOnError   = flag.Bool("stop-on-error", false, "Stop all requests on first error")
-	flagExcelExport   = flag.Bool("excel-export", true, "Use Excel-compatible formulas instead of raw values")
+	flagExcelExport   = flag.Bool("excel-export", true, "Use Excel-compatible formulas instead of raw values for calculated fields")
 	flagCiMode        = flag.Bool("ci", false, "Run in CI mode and disable prompts")
 )
 

--- a/cmd/ssl/main.go
+++ b/cmd/ssl/main.go
@@ -26,6 +26,7 @@ var (
 	flagOutputDir     = flag.String("output-dir", ".", "Output directory for CSV files")
 	flagMaxParallel   = flag.Int("max-concurrent", 5, "Number of concurrent requests when loading roster files")
 	flagStopOnError   = flag.Bool("stop-on-error", false, "Stop all requests on first error")
+	flagExcelExport   = flag.Bool("excel-export", true, "Use Excel-compatible formulas instead of raw values")
 	flagCiMode        = flag.Bool("ci", false, "Run in CI mode and disable prompts")
 )
 
@@ -44,6 +45,7 @@ func main() {
 		DownloadFiles: *flagDownloadFiles,
 		RosterDir:     *flagRostersDir,
 		OutputDir:     *flagOutputDir,
+		ExcelExport:   *flagExcelExport,
 	}
 
 	ciMode := true
@@ -134,7 +136,7 @@ func main() {
 
 	pw.Stop()
 
-	_, err = core.ExportToCsv(rosters, opts.OutputDir, "ssl_players_", "SSL Player List")
+	_, err = core.ExportToCsv(rosters, opts.OutputDir, opts.ExcelExport, "ssl_players_", "SSL Player List")
 	if err != nil {
 		log.Fatalf("Failed to create output CSV file: %v", err)
 	}

--- a/cmd/ssl/main.go
+++ b/cmd/ssl/main.go
@@ -26,7 +26,7 @@ var (
 	flagOutputDir     = flag.String("output-dir", ".", "Output directory for CSV files")
 	flagMaxParallel   = flag.Int("max-concurrent", 5, "Number of concurrent requests when loading roster files")
 	flagStopOnError   = flag.Bool("stop-on-error", false, "Stop all requests on first error")
-	flagExcelExport   = flag.Bool("excel-export", true, "Use Excel-compatible formulas instead of raw values")
+	flagExcelExport   = flag.Bool("excel-export", true, "Use Excel-compatible formulas instead of raw values for calculated fields")
 	flagCiMode        = flag.Bool("ci", false, "Run in CI mode and disable prompts")
 )
 

--- a/internal/core/csv_export.go
+++ b/internal/core/csv_export.go
@@ -155,6 +155,7 @@ func ExportToCsv(rosters []*RosterFile, outputDir string, useExcelFormulas bool,
 		}
 	}
 
+	minColIdx := slices.Index(headers, "Min")
 	hasInfo := false
 	// write each club as a CSV row
 	records := [][]string{}
@@ -171,7 +172,6 @@ func ExportToCsv(rosters []*RosterFile, outputDir string, useExcelFormulas bool,
 				if i > 0 { // skip header row
 					fields := append([]string{r.Name, r.Code, r.League}, row...)
 					// add <stat>/min col values
-					minColIdx := slices.Index(headers, "Min")
 					if minColIdx > -1 && len(fields) > minColIdx {
 						minsPlayed := getColInt(fields, minColIdx)
 						for _, statName := range statCols {
@@ -188,12 +188,8 @@ func ExportToCsv(rosters []*RosterFile, outputDir string, useExcelFormulas bool,
 									}
 								}
 								fields = slices.Insert(fields, statColIdx+1, val)
-							} else {
-								color.Yellow("%s column index not found", statName)
 							}
 						}
-					} else {
-						color.Yellow("Min column index not found")
 					}
 					// add wage and value columns
 					if r.InfoRows != nil {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -7,6 +7,7 @@ type ScraperOptions struct {
 	DownloadFiles bool
 	RosterDir     string
 	OutputDir     string
+	ExcelExport   bool
 }
 
 type RosterLoader interface {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"player-scraper/internal/core"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -137,6 +138,14 @@ func validatePathDir(v string) error {
 	return nil
 }
 
+func validateBool(v string) error {
+	if strings.ToLower(v) != "y" && strings.ToLower(v) != "n" {
+		return errors.New("must be 'y' or 'n'")
+	}
+
+	return nil
+}
+
 func getInputsForMode(mode ScrapeMode) []FormInputModel {
 	var cwd, err = os.Getwd()
 	if err != nil {
@@ -145,6 +154,7 @@ func getInputsForMode(mode ScrapeMode) []FormInputModel {
 
 	inputs := []FormInputModel{
 		{id: "outputDir", field: createInputModel("Report output dir: ", cwd, 255, validatePathDir)},
+		{id: "excelExport", field: createInputModel("Use Excel formulas: ", "y", 1, validateBool)},
 	}
 
 	if mode != ScrapeOnly {
@@ -208,6 +218,7 @@ func Run(appName string) (core.ScraperOptions, bool) {
 		DownloadFiles: mo.mode == ScrapeAndDownload,
 		RosterDir:     "",
 		OutputDir:     getFormValue("outputDir"),
+		ExcelExport:   strings.ToLower(getFormValue("excelExport")) == "y",
 	}
 
 	if mo.mode != ScrapeOnly {


### PR DESCRIPTION
Adds a few additional columns to the default export:

- `Sav/min` = Saves per minute
- `Ktk/min` = Key tackles per minute
- `Kps/min` = Key passes per minute
- `Gls/min` = Goals per minute

Option to determine whether you want Excel compatible formulas can be set as a flag (`excel-export`) or via the UI.

Also includes a couple of small bug fixes.