### PR TITLE
Fix bug - use of 'q' key does not cancel scrape

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -7,6 +7,7 @@ import (
 	"player-scraper/internal/core"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -66,6 +67,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// detect cancel propagation from list view ('q' key mainly)
+		if m.step == 0 && key.Matches(msg, m.list.KeyMap.Quit) {
+			m.cancelled = true
+			return m, tea.Quit
+		}
+
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
 			m.cancelled = true


### PR DESCRIPTION
As indicated in the help menu, the 'q' key should cancel the scrape when on the list view. Currently, when the user presses 'q' the scrape proceeds with default values.